### PR TITLE
Feature/upgrade mongoid 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+*.swp

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in join_collection.gemspec
 gemspec
+gem 'pry'

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in join_collection.gemspec
 gemspec
-gem 'pry'

--- a/lib/join_collection.rb
+++ b/lib/join_collection.rb
@@ -4,7 +4,11 @@ class JoinCollection
 
   VERSION = "0.2.0"
 
-  class Doc; include Mongoid::Document; end
+  class Doc 
+    include Mongoid::Document
+    include Mongoid::Attributes::Dynamic
+  end
+
 
   attr_reader :source_objects
   attr_accessor :join_type, :singular_target, :plural_target

--- a/lib/join_collection.rb
+++ b/lib/join_collection.rb
@@ -1,4 +1,5 @@
 require 'mongoid'
+require 'pry'
 
 class JoinCollection
 
@@ -86,7 +87,7 @@ class JoinCollection
         when plural_target
           doc[plural_target] = target_objects if join_type == :join_many
         else
-          doc["#{singular_target}_#{field}"] = target_object.try(field)
+          doc["#{singular_target}_#{field}"] = target_object.try!(field)
         end
       end
     end

--- a/lib/join_collection.rb
+++ b/lib/join_collection.rb
@@ -1,5 +1,4 @@
 require 'mongoid'
-require 'pry'
 
 class JoinCollection
 

--- a/spec/join_collection_spec.rb
+++ b/spec/join_collection_spec.rb
@@ -109,7 +109,7 @@ describe JoinCollection do
       @user_collection.join_many(:post, Post,
         :relation => {:user_id => :mysql_id}, :delegation => {:fields => [:content, :published]})
       expect(@user_collection.source_objects.first.post_content).to eq('text 2')
-      expect(@user_collection.source_objects.first.post_published).to be_true
+      expect(@user_collection.source_objects.first.post_published).to be_truthy
     end
 
     it 'should have correct values in delegation fields if a conditional block given' do
@@ -117,7 +117,7 @@ describe JoinCollection do
         :relation => {:user_id => :mysql_id},
         :delegation => {:if => lambda { |x| x.published == false }, :fields => [:content, :published]})
       expect(@user_collection.source_objects.first.post_content).to eq('text 3')
-      expect(@user_collection.source_objects.first.post_published).to be_false
+      expect(@user_collection.source_objects.first.post_published).to be_falsey
     end
   end
 

--- a/spec/join_collection_spec.rb
+++ b/spec/join_collection_spec.rb
@@ -1,6 +1,4 @@
 require 'spec_helper'
-require 'pry'
-
 
 class User
   include Mongoid::Document

--- a/spec/join_collection_spec.rb
+++ b/spec/join_collection_spec.rb
@@ -38,11 +38,11 @@ describe JoinCollection do
   describe '#join_to' do
     before do
       @post_collection = JoinCollection.new([post1])
-      User.stub(:where).and_return([user1])
+      allow(User).to receive(:where).and_return([user1])
     end
 
     it 'should call User.where' do
-      User.should_receive(:where).with(:mysql_id.in => [1]).and_return([user1])
+      expect(User).to receive(:where).with(:mysql_id.in => [1]).and_return([user1])
       @post_collection.join_to(:user, User, :relation => {:user_id => :mysql_id}, :delegation => {:fields => [:mysql_id]})
     end
 
@@ -67,11 +67,11 @@ describe JoinCollection do
   describe '#join_one' do
     before do
       @user_collection = JoinCollection.new([user1])
-      Post.stub(:where).and_return([post1])
+      allow(Post).to receive(:where).and_return([post1])
     end
 
     it 'should call Post.where' do
-      Post.should_receive(:where).with(:user_id.in => [1]).and_return([post1])
+      expect(Post).to receive(:where).with(:user_id.in => [1]).and_return([post1])
       @user_collection.join_one(:post, Post, :relation => {:user_id => :mysql_id}, :delegation => {:fields => [:mysql_id]})
     end
 
@@ -96,7 +96,7 @@ describe JoinCollection do
   describe '#join_many' do
     before do
       @user_collection = JoinCollection.new([user2])
-      Post.stub(:where).and_return([post2, post3])
+      allow(Post).to receive(:where).and_return([post2, post3])
     end
 
     it 'should catch the whole target objects if the delegation field name equals to the plural target name' do
@@ -124,7 +124,7 @@ describe JoinCollection do
   context 'source objects are hash objects' do
     it 'can still join to target object' do
       user = User.new(:mysql_id => 1, :name => 'Bob')
-      User.stub(:where).and_return([user])
+      allow(User).to receive(:where).and_return([user])
 
       post = {:mysql_id => 1, :user_id => 1, :content => 'text 1', :published => true}
       post_collection = JoinCollection.new([post])
@@ -134,7 +134,7 @@ describe JoinCollection do
 
     it 'can still join one target object' do
       post = Post.new(:mysql_id => 1, :user_id => 1, :content => 'text 1', :published => true)
-      Post.stub(:where).and_return([post])
+      allow(Post).to receive(:where).and_return([post])
 
       user = {:mysql_id => 1, :name => 'Bob'}
       user_collection = JoinCollection.new([user])
@@ -144,7 +144,7 @@ describe JoinCollection do
 
     it 'can still join many target objects' do
       post = Post.new(:mysql_id => 1, :user_id => 1, :content => 'text 1', :published => true)
-      Post.stub(:where).and_return([post])
+      allow(Post).to receive(:where).and_return([post])
 
       user = {:mysql_id => 1, :name => 'Bob'}
       user_collection = JoinCollection.new([user])

--- a/spec/join_collection_spec.rb
+++ b/spec/join_collection_spec.rb
@@ -1,8 +1,15 @@
 require 'spec_helper'
+require 'pry'
 
 
-class User; include Mongoid::Document; end
-class Post; include Mongoid::Document; end
+class User
+  include Mongoid::Document
+  include Mongoid::Attributes::Dynamic
+end
+class Post
+  include Mongoid::Document
+  include Mongoid::Attributes::Dynamic
+end
 
 describe JoinCollection do
   let!(:user1) { User.new :mysql_id => 1, :name => 'Bob' }


### PR DESCRIPTION
- add `include Mongoid::Attributes::Dynamic` for not existed attributes operation
- upgrade rspec syntax to version 3
- using method from `try` to `try!` to raise an exception error.

If there is another project using this gem, we may consider the gem version for different `mongoid`.
